### PR TITLE
Fix jest toBeCloseTo function signature

### DIFF
--- a/types/jest/index.d.ts
+++ b/types/jest/index.d.ts
@@ -353,8 +353,9 @@ declare namespace jest {
         /**
          * Using exact equality with floating point numbers is a bad idea.
          * Rounding means that intuitive things fail.
+         * The default for numDigits is 2.
          */
-        toBeCloseTo(expected: number, delta?: number): R;
+        toBeCloseTo(expected: number, numDigits?: number): R;
         /**
          * Ensure that a variable is not undefined.
          */


### PR DESCRIPTION
The second argument passed in is not the amount that the number should be within, but is actually the number of significant digits to check. 

Reference: https://github.com/facebook/jest/blob/master/docs/en/ExpectAPI.md#tobeclosetonumber-numdigits

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code. (Compile and run.)
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [ ] Increase the version number in the header if appropriate.
- [ ] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

